### PR TITLE
9 6 root env var fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+PROJECT_ROOT='/workspace/terraform-beginner-bootcamp-2023'

--- a/README.md
+++ b/README.md
@@ -109,15 +109,46 @@ vscode:
     - hashicorp.terraform
 ```
 
-#### <u>Issue 4:</u> Update Gitpod seting
+#### <u>Issue 4:</u> Update Gitpod setting
 
 While using GitPod workspace, it was noticed that the GitHub username/password credntials were required every time that a new pull/push was executed. This issue section will explain how to fix this. 
  
-##### <u>Resolution:</u> Update Gitpod seting
+##### <u>Resolution:</u> Update Gitpod setting
 
 In order to resolve the Gitpod permission issue, the *Git Providers*[^6] settings required to be modifed under to allow Git to work properly. The *Git Providers* settings needs to be modify under User Settings > [Git Providers](https://gitpod.io/user/integrations).
 
+#### <u>Issue 5:</u> Create a new env var file
 
+There was some issue with the current bash script for the install terraform CLI. A new root env var file was required to fix this. 
+ 
+##### <u>Resolution:</u> Update Gitpod seting
+
+To fix the issue with installing_terraform_cli bash file, a new env var required to be created. These are some of the steps used to fix this issue:
+
+1. Create a new folder `.env.example` to define the new root env var:
+
+    .env.example
+       
+        PROJECT_ROOT='/workspace/terraform-beginner-bootcamp-2023'
+  
+2. Update the install_terraform_cli.sh bash file with the following
+  
+     cd /workspace
+     
+     cd $PROJECT_ROOT
+
+3. Define the env varibale 
+
+      ```sh
+      gp env PROJECT_ROOT='/workspace/terraform-beginner-bootcamp-2023'
+      ```
+  
+
+4. To print the env variable
+
+      ```sh
+      echo $PROJECT_ROOT
+      ```
 
 ### <u>Support Links</u>:
 

--- a/bin/installing_terraform_cli.sh
+++ b/bin/installing_terraform_cli.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env-bash
 
+cd /workspace
+
 sudo apt-get update && sudo apt-get install -y gnupg software-properties-common curl
 
 wget -O- https://apt.releases.hashicorp.com/gpg | \
@@ -17,3 +19,5 @@ sudo tee /etc/apt/sources.list.d/hashicorp.list
 sudo apt update
 
 sudo apt-get install terraform -y
+
+cd $PROJECT_ROOT


### PR DESCRIPTION
Creating a new .env.example file to configure the new root env var for the terraform cli bash file